### PR TITLE
fix: scope runner configUrl to blog repo

### DIFF
--- a/apps/base/actions-runner/scale-set/release.yaml
+++ b/apps/base/actions-runner/scale-set/release.yaml
@@ -17,4 +17,4 @@ spec:
     runnerScaleSet:
       name: "app"
       github:
-        configUrl: "https://github.com/josmase"
+        configUrl: "https://github.com/josmase/blog"

--- a/charts/arc-runner-setup/values.yaml
+++ b/charts/arc-runner-setup/values.yaml
@@ -15,8 +15,8 @@ runnerScaleSet:
 
   # GitHub configuration
   github:
-    # User account URL (all repos)
-    configUrl: "https://github.com/josmase"
+    # Repository URL (runner registers at repo level)
+    configUrl: "https://github.com/josmase/blog"
     # Secret name containing GitHub token (must exist in namespace)
     configSecret: "controller-manager"
 


### PR DESCRIPTION
ARC does not support org-level configUrl for personal GitHub accounts. The GitHub API requires runner registration at repo-level scope.

This changes configUrl from https://github.com/josmase (org-level, fails with 404) to https://github.com/josmase/blog (repo-level).

The runner scale-set name stays as `app` so existing workflows with `runs-on: app` continue to work.